### PR TITLE
fix: percent-encode query string parameters in HttpParameterHelper

### DIFF
--- a/src/RSMatrix.Tests/HttpParameterHelperTests.cs
+++ b/src/RSMatrix.Tests/HttpParameterHelperTests.cs
@@ -1,0 +1,55 @@
+using RSMatrix.Http;
+
+namespace RSMatrix.Tests;
+
+/// <summary>
+/// Tests query string construction in HttpParameterHelper.
+/// </summary>
+public class HttpParameterHelperTests
+{
+    [Test]
+    public async Task AppendParameters_NoParameters_ReturnsPathUnchanged()
+    {
+        await Assert.That(HttpParameterHelper.AppendParameters("/_matrix/client/v3/sync", [])).IsEqualTo("/_matrix/client/v3/sync");
+    }
+
+    [Test]
+    public async Task AppendParameters_NullParameters_ReturnsPathUnchanged()
+    {
+        await Assert.That(HttpParameterHelper.AppendParameters("/_matrix/client/v3/sync", null!)).IsEqualTo("/_matrix/client/v3/sync");
+    }
+
+    [Test]
+    public async Task AppendParameters_SimpleValues_AppendsQueryString()
+    {
+        var parameters = new[] { KeyValuePair.Create("dir", "b"), KeyValuePair.Create("limit", "10") };
+        await Assert.That(HttpParameterHelper.AppendParameters("/_matrix/client/v3/rooms/!room:example.org/messages", parameters))
+            .IsEqualTo("/_matrix/client/v3/rooms/!room:example.org/messages?dir=b&limit=10");
+    }
+
+    [Test]
+    public async Task AppendParameters_ReservedCharactersArePercentEncoded()
+    {
+        // 'since' tokens are opaque strings and may contain characters that are reserved in query strings
+        var parameters = new[] { KeyValuePair.Create("since", "s123+456&abc=def#ghi") };
+        await Assert.That(HttpParameterHelper.AppendParameters("/_matrix/client/v3/sync", parameters))
+            .IsEqualTo("/_matrix/client/v3/sync?since=s123%2B456%26abc%3Ddef%23ghi");
+    }
+
+    [Test]
+    public async Task AppendParameters_SpacesAreEncodedAsPercent20()
+    {
+        // Uri.EscapeDataString encodes spaces as %20, unlike HttpUtility.UrlEncode which produces '+'
+        var parameters = new[] { KeyValuePair.Create("filter", "my filter") };
+        await Assert.That(HttpParameterHelper.AppendParameters("/_matrix/client/v3/sync", parameters))
+            .IsEqualTo("/_matrix/client/v3/sync?filter=my%20filter");
+    }
+
+    [Test]
+    public async Task AppendParameters_KeysAreEncodedToo()
+    {
+        var parameters = new[] { KeyValuePair.Create("weird key", "value") };
+        await Assert.That(HttpParameterHelper.AppendParameters("/path", parameters))
+            .IsEqualTo("/path?weird%20key=value");
+    }
+}

--- a/src/RSMatrix/Http/HttpClientHelper.cs
+++ b/src/RSMatrix/Http/HttpClientHelper.cs
@@ -135,8 +135,11 @@ public static class HttpParameterHelper
         if (parameters == null)
             return path;
 
-        //var formattedParameters = string.Join("&", parameters.Select(kvp => $"{HttpUtility.UrlEncode(kvp.Key)}={HttpUtility.UrlEncode(kvp.Value)}"));
-        var formattedParameters = string.Join("&", parameters.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+        // Keys and values must be percent-encoded, otherwise parameters containing characters
+        // that are reserved in query strings (e.g. '&', '=', '#', '+', ' ') break the request.
+        // Uri.EscapeDataString is used instead of HttpUtility.UrlEncode because the latter
+        // encodes spaces as '+', which is only correct for form data, not for query strings.
+        var formattedParameters = string.Join("&", parameters.Select(kvp => $"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}"));
         if (string.IsNullOrWhiteSpace(formattedParameters))
             return path;
 


### PR DESCRIPTION
## Summary

`HttpParameterHelper.AppendParameters` builds query strings without any URL encoding. Matrix `since`/`from`/`filter` values are opaque strings per spec and may contain characters that are reserved in query strings (`&`, `=`, `#`, `+`, space). With such values the resulting URL is malformed (parameters get split, the query is truncated at `#`, `+` is decoded as a space by the server).

## Change

- Encode both keys and values with `Uri.EscapeDataString` before joining them into the query string.
- `Uri.EscapeDataString` is preferred over the previously commented-out `HttpUtility.UrlEncode` because the latter encodes spaces as `+`, which is only valid for form data — in query strings a space must be `%20`.
- Added unit tests covering: no parameters, null parameters, simple values, reserved characters, spaces, and key encoding.

No public API changes.